### PR TITLE
refactor: modularize styles

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -16,6 +16,8 @@ import {
 import { useLocalStorage, useOnlineStatus, useToast } from './hooks/useLocalStorage'
 import { validateInputs, calculateTCO, TRUCK_CONFIGS, formatCurrency, formatNumber, formatPercentage } from './utils/calculations'
 import { generateTCOReport, exportDataAsJSON } from './utils/pdfGenerator'
+import './styles/form.css'
+import './styles/components.css'
 
 export default function App() {
   // Estados principales

--- a/main.jsx
+++ b/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import './index.css'
+import './styles/layout.css'
 import { registerSW } from 'virtual:pwa-register'
 
 // Registrar Service Worker con actualización automática

--- a/styles/components.css
+++ b/styles/components.css
@@ -1,165 +1,3 @@
-/* Reset y variables CSS */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-:root {
-  --primary-color: #0d47a1;
-  --primary-light: #5472d3;
-  --primary-dark: #002171;
-  --secondary-color: #f57c00;
-  --background: #f5f5f5;
-  --surface: #ffffff;
-  --error: #d32f2f;
-  --success: #388e3c;
-  --text-primary: #212121;
-  --text-secondary: #757575;
-  --border: #e0e0e0;
-  --shadow: 0 2px 4px rgba(0,0,0,0.1);
-  --shadow-lg: 0 4px 8px rgba(0,0,0,0.15);
-}
-
-body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: var(--background);
-  color: var(--text-primary);
-  line-height: 1.6;
-}
-
-.app {
-  min-height: 100vh;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1rem;
-}
-
-/* Header */
-.header {
-  background: linear-gradient(135deg, var(--primary-color), var(--primary-light));
-  color: white;
-  padding: 2rem;
-  border-radius: 12px;
-  margin-bottom: 2rem;
-  text-align: center;
-  box-shadow: var(--shadow-lg);
-}
-
-.header h1 {
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
-}
-
-.header p {
-  opacity: 0.9;
-  font-size: 1.1rem;
-}
-
-/* Status indicators */
-.status-bar {
-  display: flex;
-  gap: 1rem;
-  margin-bottom: 2rem;
-  flex-wrap: wrap;
-}
-
-.status-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: var(--surface);
-  border-radius: 25px;
-  font-size: 0.9rem;
-  box-shadow: var(--shadow);
-}
-
-.status-online { border-left: 4px solid var(--success); }
-.status-offline { border-left: 4px solid var(--error); }
-.status-cached { border-left: 4px solid var(--secondary-color); }
-
-/* Form styles */
-.form-grid {
-  display: grid;
-  gap: 2rem;
-  margin-bottom: 2rem;
-}
-
-@media (min-width: 768px) {
-  .form-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-.form-section {
-  background: var(--surface);
-  padding: 1.5rem;
-  border-radius: 12px;
-  box-shadow: var(--shadow);
-}
-
-.form-section h3 {
-  color: var(--primary-color);
-  margin-bottom: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.form-group {
-  margin-bottom: 1rem;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.form-group input,
-.form-group select {
-  width: 100%;
-  padding: 0.75rem;
-  border: 2px solid var(--border);
-  border-radius: 8px;
-  font-size: 1rem;
-  transition: border-color 0.2s;
-}
-
-.form-group input:focus,
-.form-group select:focus {
-  outline: none;
-  border-color: var(--primary-color);
-}
-
-.input-group {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.input-addon {
-  background: var(--background);
-  padding: 0.75rem;
-  border: 2px solid var(--border);
-  border-radius: 8px;
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-
-/* Error styles */
-.error {
-  color: var(--error);
-  font-size: 0.875rem;
-  margin-top: 0.25rem;
-}
-
-.input-error {
-  border-color: var(--error) !important;
-}
-
 /* Results section */
 .results {
   background: var(--surface);
@@ -341,39 +179,23 @@ body {
 
 /* Responsive design */
 @media (max-width: 768px) {
-  .app {
-    padding: 0.5rem;
-  }
-  
-  .header {
-    padding: 1.5rem;
-  }
-  
-  .header h1 {
-    font-size: 1.5rem;
-  }
-  
-  .form-section {
-    padding: 1rem;
-  }
-  
   .results {
     padding: 1rem;
   }
-  
+
   .total-tco .value {
     font-size: 2rem;
   }
-  
+
   .actions {
     justify-content: stretch;
   }
-  
+
   .btn {
     flex: 1;
     justify-content: center;
   }
-  
+
   .toast {
     right: 1rem;
     left: 1rem;
@@ -414,3 +236,23 @@ body {
 }
 
 .category-percentage {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.breakdown-bar {
+  background: var(--border);
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.breakdown-fill {
+  height: 100%;
+}
+
+.breakdown-amount {
+  text-align: right;
+  font-weight: 600;
+  color: var(--text-primary);
+}

--- a/styles/form.css
+++ b/styles/form.css
@@ -1,0 +1,86 @@
+/* Form styles */
+.form-grid {
+  display: grid;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+@media (min-width: 768px) {
+  .form-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.form-section {
+  background: var(--surface);
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+}
+
+.form-section h3 {
+  color: var(--primary-color);
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.form-group input,
+.form-group select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: var(--primary-color);
+}
+
+.input-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.input-addon {
+  background: var(--background);
+  padding: 0.75rem;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* Error styles */
+.error {
+  color: var(--error);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.input-error {
+  border-color: var(--error) !important;
+}
+
+@media (max-width: 768px) {
+  .form-section {
+    padding: 1rem;
+  }
+}

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -1,0 +1,94 @@
+/* Reset y variables CSS */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --primary-color: #0d47a1;
+  --primary-light: #5472d3;
+  --primary-dark: #002171;
+  --secondary-color: #f57c00;
+  --background: #f5f5f5;
+  --surface: #ffffff;
+  --error: #d32f2f;
+  --success: #388e3c;
+  --text-primary: #212121;
+  --text-secondary: #757575;
+  --border: #e0e0e0;
+  --shadow: 0 2px 4px rgba(0,0,0,0.1);
+  --shadow-lg: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--background);
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.app {
+  min-height: 100vh;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* Header */
+.header {
+  background: linear-gradient(135deg, var(--primary-color), var(--primary-light));
+  color: white;
+  padding: 2rem;
+  border-radius: 12px;
+  margin-bottom: 2rem;
+  text-align: center;
+  box-shadow: var(--shadow-lg);
+}
+
+.header h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.header p {
+  opacity: 0.9;
+  font-size: 1.1rem;
+}
+
+/* Status indicators */
+.status-bar {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+}
+
+.status-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--surface);
+  border-radius: 25px;
+  font-size: 0.9rem;
+  box-shadow: var(--shadow);
+}
+
+.status-online { border-left: 4px solid var(--success); }
+.status-offline { border-left: 4px solid var(--error); }
+.status-cached { border-left: 4px solid var(--secondary-color); }
+
+@media (max-width: 768px) {
+  .app {
+    padding: 0.5rem;
+  }
+
+  .header {
+    padding: 1.5rem;
+  }
+
+  .header h1 {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- split global index.css into modular layout, form, and component styles
- update React entry points to load the new CSS modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_b_68a4bd6f4ab4832a921827cffd00f2c1