### PR TITLE
docs: add usage and PWA info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # mi-pwa
 Calculadora de TCO — Zapata Camiones (PWA)
+
+## Instalación y uso
+
+1. Instalar dependencias:
+   ```bash
+   npm install
+   ```
+2. Iniciar el entorno de desarrollo con recarga en caliente:
+   ```bash
+   npm run dev
+   ```
+3. Generar la versión optimizada para producción:
+   ```bash
+   npm run build
+   ```
+
+## Características PWA
+
+- Integración con `vite-plugin-pwa` y registro de service worker con `autoUpdate`.
+- Caché de recursos estáticos y de peticiones a la API mediante Workbox.
+- Manifiesto con nombre, colores y conjunto de iconos que permite instalar la aplicación en dispositivos.
+
+## Generación de iconos
+
+La aplicación utiliza varios iconos declarados en el manifiesto para distintos dispositivos y tamaños. Para generarlos a partir de una imagen base se puede ejecutar:
+
+```bash
+npm run generate-icons
+```
+
+El comando genera los archivos en la carpeta `public/icons` para que sean incluidos durante la compilación.


### PR DESCRIPTION
## Summary
- document installation and development commands
- outline PWA capabilities and icon generation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve entry module "index.html")

------
https://chatgpt.com/codex/tasks/task_b_68a4bd7015e0832aba631aac6b80b79d